### PR TITLE
prevent duplicate and delayed bp notices

### DIFF
--- a/includes/buddypress-docs.php
+++ b/includes/buddypress-docs.php
@@ -397,3 +397,27 @@ function hc_custom_bp_docs_folders_meta_box() {
 
 	<?php
 }
+
+/**
+ * Prevent duplicate and delayed buddypress notifications from showing.
+ *
+ * This addresses @link https://github.com/MESH-Research/commons/issues/77
+ *
+ * This function is not called directly. It is called through the
+ * 'bp_core_render_message' action, which occurs immediately after a buddypress
+ * notification has been displayed.
+ * @see buddypress/bp-core/bp-core-functions.php bp_core_render_message()
+ *
+ * @author Mike Thicke
+ *
+ * @global $bp The BuddyPress object.
+ */
+function hcommons_prevent_bp_message_duplicates() {
+	global $bp;
+	$bp->template_message = null; //Prevent message from being shown twice.
+
+	// Prevent message from being shown on next page load.
+	@setcookie( 'bp-message', false, time() - 1000, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
+	@setcookie( 'bp-message-type', false, time() - 1000, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
+}
+add_action( 'bp_core_render_message', array( $this, 'prevent_bp_message_duplicates' ), 10 );


### PR DESCRIPTION
This addresses an issue where duplicate and delayed notifications were being displayed for file operations when AJAX requests were involved.

> The following function, triggered after a notification is displayed, appears to solve the issue:
> 
> 
> ```
> public function hcommons_prevent_bp_message_duplicates() {
> 		global $bp;
> 		$bp->template_message = null;
> 
> 		@setcookie( 'bp-message', false, time() - 1000, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
> 		@setcookie( 'bp-message-type', false, time() - 1000, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
> 	}
> ```
> 
> This function does two things:
> 
> 1. It prevents a message from being displayed twice on the same page load. This is because the 'template_notices' action is triggered twice on docs and files page loads: once in the group header and once in the documents template. I think this is a change introduced by the upgrade. Without this, you can sometimes see the same message displayed twice: once as a pop-up, and second as an inline message above the documents list. Or, if an AJAX request is responsible, there will be two messages, out-of-step.
> 2. It removes the cookie for displaying the message, if it exists.
> 
> This function only triggers after a message is displayed, so it shouldn't cause any notifications to go unseen.




closes MESH-Research/commons#77