### PR TITLE
prevent critical error on event creation

### DIFF
--- a/includes/bp-event-organiser.php
+++ b/includes/bp-event-organiser.php
@@ -309,7 +309,7 @@ function hc_custom_bpeo_maybe_hook_ics_attachments( $args, $email_type ) {
 	);
 
 	if ( 200 !== wp_remote_retrieve_response_code( $request ) ) {
-		return;
+		return $args;
 	}
 
 	$GLOBALS['bpeo_event_ical'] = wp_remote_retrieve_body( $request );


### PR DESCRIPTION
The ```hc_custom_bpeo_maybe_hook_ics_attachments``` filter currently clears the $args argument unintentionally when ```wp_remote_retrieve_response_code``` fails to have a response code of 200. This has the effect of clearing all of the email data, which causes a crash when sending notifications for event creation. I'm not sure why  ```wp_remote_retrieve_response_code``` isn't 200, but regardless it shouldn't be causing a crash when it fails, but instead should just stop trying to add the ics attachment.

closes MESH-Research/commons#75