### PR TITLE
block spam messages that made it through akismet

### DIFF
--- a/includes/buddypress/bp-activity.php
+++ b/includes/buddypress/bp-activity.php
@@ -34,5 +34,31 @@ function hc_custom_template_part_filter( $templates, $slug, $name ) {
 
 	return $templates;
 }
-
 add_filter( 'bp_get_template_part', 'hc_custom_template_part_filter', 10, 3 );
+
+/**
+ * Mark messages as spam that Akismet might have missed but we know are spam.
+ *
+ * Note: this is a temporary fix, and we probably want a more robust way of doing this.
+ *
+ * @author Mike Thicke
+ *
+ * @param BP_Activity_Activity $activity The activity item to check.
+ */
+function hc_custom_check_activity( $activity ) {
+	if ( empty( $activity->content ) ) {
+		return;
+	}
+
+	$blocked_patterns = [
+		'/mend testing our new project -.*http:\/\//i',
+	];
+
+	foreach ( $blocked_patterns as $pattern ) {
+		if ( preg_match( $pattern, $activity->content ) ) {
+			bp_activity_mark_as_spam( $activity );
+			break;
+		}
+	}
+}
+add_action( 'bp_activity_before_save', 'hc_custom_check_activity', 10, 1 );


### PR DESCRIPTION
Checks messages for specific patterns and marks them as spam if there is a match. This also has the effect of marking the user as a spammer.