### PR TITLE
fix display of join button for society non-members

### DIFF
--- a/includes/buddypress/bp-groups.php
+++ b/includes/buddypress/bp-groups.php
@@ -64,7 +64,7 @@ function hcommons_add_non_society_member_join_group_button() {
 		if ( empty( $group ) ) {
 			$group =& $groups_template->group;
 		}
-		$is_not_committee = strtolower( \groups_get_groupmeta( $group->id, 'society_group_type', true ) ) !== 'committee';
+		$is_not_committee = hc_custom_get_group_type() !== 'committee';
 
 		if ( $is_not_committee ) {
 			$message = 'Join Group';


### PR DESCRIPTION
On UP Commons groups, non-society members were being presented with two buttons: on top, the button a society member would see, and on the bottom, the button that they, as non-members were supposed to see. Additionally, committees sometimes showed join or request membership buttons when they should not.

This PR makes a number of changes:
- Alters the logic of ```hc_custom_get_group_type``` to check for mla committee membership and to fall back to group->status as group type if other methods fail. It seems in the past there were multiple methods of denoting whether a group is a committee, and this function now attempts to account for those.
- Alters other functions to use ```hc_custom_get_group_type``` as the way to check for group type.
- Stops ```hc_custom_hide_join_button``` from displaying a join button in cases where ```hcommons_add_non_society_member_join_group_button``` will add the button. This prevents the duplicate button problem.


closes MESH-Research/commons#100